### PR TITLE
Idle Timeout Setting

### DIFF
--- a/src/main/resources/org/jenkinsci/main/modules/sshd/SSHD/config.groovy
+++ b/src/main/resources/org/jenkinsci/main/modules/sshd/SSHD/config.groovy
@@ -6,4 +6,7 @@ f.section(title:_("SSH Server")) {
     f.entry(title:_("SSHD Port"),field:"port") {
         f.serverTcpPort()
     }
+    f.entry(title:"Idle Timeout (sec)",field:"idleTimeout") {
+        f.number(clazz:"number",min:1,step:1);
+    }
 }

--- a/src/main/resources/org/jenkinsci/main/modules/sshd/SSHD/help-idleTimeout.html
+++ b/src/main/resources/org/jenkinsci/main/modules/sshd/SSHD/help-idleTimeout.html
@@ -1,0 +1,4 @@
+<div>
+    If SSHD connection is idle (i.e. there is no any input or output) longer than the specified time,
+    Jenkins would close the connection.
+</div>

--- a/src/test/java/org/jenkinsci/main/modules/ssh/SSHDTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/ssh/SSHDTest.java
@@ -23,5 +23,11 @@ public class SSHDTest extends HudsonTestCase {
             configRoundtrip();
             assertEquals(i,sshd.getPort());
         }
+
+        for (int i : new int[]{-1, 0, 1000}) {
+            sshd.setIdleTimeout(i);
+            configRoundtrip();
+            assertEquals(i < 1 ? SSHD.DEFAULT_TIMEOUT_SEC : i, sshd.getIdleTimeout());
+        }
     }
 }


### PR DESCRIPTION
By default, SshServer closes connection if it is idle for 10 minutes. It is not convenient when, for example, we are running 'build -s' command and waiting for a lengthy build.

I offer to allow user to set timeout time as he need.
