### PR TITLE
Enable a CTR cypher.

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -11,6 +11,7 @@ import net.sf.json.JSONObject;
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.AES128CBC;
+import org.apache.sshd.common.cipher.AES128CTR;
 import org.apache.sshd.common.cipher.BlowfishCBC;
 import org.apache.sshd.common.cipher.TripleDESCBC;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;


### PR DESCRIPTION
CBC cyphers are currently not supported by some SSH implementations , such as Go's, making it difficult to write a client able to connect to Jenkins' SSH daemon.
