### PR TITLE
set client idle timeout to 3 hours

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -106,6 +106,9 @@ public class SSHD extends GlobalConfiguration {
 
         sshd.setPublickeyAuthenticator(new PublicKeyAuthenticatorImpl());
 
+        // set idle timeout to 3 hours
+        sshd.getProperties().put(org.apache.sshd.server.ServerFactoryManager.IDLE_TIMEOUT, String.valueOf(3*60*60*1000));
+
         sshd.start();
         LOGGER.info("Started SSHD at port " + sshd.getPort());
     }


### PR DESCRIPTION
We have a scenario where one Jenkins instance (the Dev Jenkins) triggers a job in another instance (deployment job in Ops Jenkins) via SSH and waits for job completion. The Dev Jenkins job wants to know the completion status of job in Ops Jenkins and also needs to include output of job triggered in Ops Jenkins.

Everything works fine if the Ops Jenkins completes quickly. Sometimes the deployment job takes a bit longer (restarts, orchestrations) and then the Dev Jenkins receives timeout, failing entire deployment pipeline, despite the fact that deployment job continues and eventually succeeds.

This tiny patch sets client idle timeout to 3 hours, which is better than infinity and more than enough for our case.