### PR TITLE
[JENKINS-39805] - Drop CBC: https://www.kb.cert.org/vuls/id/958563

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -10,10 +10,7 @@ import jenkins.util.ServerTcpPort;
 import net.sf.json.JSONObject;
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.common.cipher.AES128CBC;
 import org.apache.sshd.common.cipher.AES128CTR;
-import org.apache.sshd.common.cipher.BlowfishCBC;
-import org.apache.sshd.common.cipher.TripleDESCBC;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
 import org.apache.sshd.server.UserAuth;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
@@ -85,10 +82,8 @@ public class SSHD extends GlobalConfiguration {
         sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthNamedFactory()));
                 
         sshd.setCipherFactories(Arrays.asList(// AES 256 and 192 requires unlimited crypto, so don't use that
-                new AES128CBC.Factory(),
-                new AES128CTR.Factory(),
-                new TripleDESCBC.Factory(),
-                new BlowfishCBC.Factory()));
+                                              // CBC modes are not secure, so dropping them
+                                              new AES128CTR.Factory()));
 
         sshd.setPort(port);
 


### PR DESCRIPTION
SSH CBC modes are highly insecure: https://www.kb.cert.org/vuls/id/958563

Every modern implementation of SSH supports AES128-CTR, so I think it's wise to use only it.

https://issues.jenkins-ci.org/browse/JENKINS-39805
