### PR TITLE
Updating sshd-core to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.24</version>
+    <version>2.25</version>
     <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>
   <artifactId>sshd</artifactId>
-  <version>1.12-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>jenkins-module</packaging>
   <name>SSH server</name>
   <description>Adds SSH server functionality to Jenkins, exposing CLI commands through it</description>
@@ -28,7 +28,8 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.54</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <dependencies>
@@ -40,7 +41,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>1.2.0</version> <!-- TODO 1.3.0 requires Java 8 -->
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>2.24</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>
@@ -27,21 +28,8 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.580.3</jenkins.version>
-    <java.level>6</java.level>
-    <jenkins-test-harness.version>1.580.3</jenkins-test-harness.version>
+    <jenkins.version>1.625.3</jenkins.version>
   </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.119</version>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
-  </build>
 
   <dependencies>
     <dependency>
@@ -52,17 +40,17 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>0.14.0</version>
+      <version>1.2.0</version> <!-- TODO 1.3.0 requires Java 8 -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>1.2</version>
+      <version>2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -3,7 +3,7 @@ package org.jenkinsci.main.modules.sshd;
 import com.trilead.ssh2.crypto.Base64;
 import com.trilead.ssh2.packets.TypesWriter;
 import hudson.model.User;
-import org.apache.sshd.server.PublickeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.session.ServerSession;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -4,29 +4,27 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import jenkins.model.GlobalConfiguration;
-import jenkins.model.GlobalConfigurationCategory;
-import jenkins.model.Jenkins;
-import jenkins.model.Jenkins.MasterComputer;
-import jenkins.util.ServerTcpPort;
-import net.sf.json.JSONObject;
-import org.apache.sshd.SshServer;
-import org.apache.sshd.common.Cipher;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.common.cipher.AES128CTR;
-import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
-import org.apache.sshd.server.UserAuth;
-import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
-import org.kohsuke.stapler.StaplerRequest;
-
-import javax.annotation.concurrent.GuardedBy;
-import javax.inject.Inject;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.GuardedBy;
+import javax.inject.Inject;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins.MasterComputer;
+import jenkins.util.ServerTcpPort;
+import net.sf.json.JSONObject;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.cipher.BuiltinCiphers;
+import org.apache.sshd.common.cipher.Cipher;
+import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -95,7 +93,7 @@ public class SSHD extends GlobalConfiguration {
                 
         sshd.setCipherFactories(Arrays.<NamedFactory<Cipher>>asList(// AES 256 and 192 requires unlimited crypto, so don't use that
                                               // CBC modes are not secure, so they have been dropped (see JENKINS-39805)
-                                              new AES128CTR.Factory()));
+                                              BuiltinCiphers.aes128ctr));
 
         sshd.setPort(port);
 
@@ -142,7 +140,7 @@ public class SSHD extends GlobalConfiguration {
         }
     }
 
-    public synchronized void stop() throws InterruptedException {
+    public synchronized void stop() throws IOException, InterruptedException {
         if (sshd!=null) {
             sshd.stop(true);
             sshd = null;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/UserAuthNamedFactory.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/UserAuthNamedFactory.java
@@ -2,9 +2,9 @@ package org.jenkinsci.main.modules.sshd;
 
 import jenkins.model.Jenkins;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthNone;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.UserAuthNoneFactory;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 
 /**
  * Depending on the current security configuration, activate either public key auth or no auth.
@@ -12,8 +12,8 @@ import org.apache.sshd.server.auth.UserAuthPublicKey;
  * @author Kohsuke Kawaguchi
  */
 class UserAuthNamedFactory implements NamedFactory<UserAuth> {
-    NamedFactory<UserAuth> publicKey = new UserAuthPublicKey.Factory();
-    NamedFactory<UserAuth> none = new UserAuthNone.Factory();
+    NamedFactory<UserAuth> publicKey = UserAuthPublicKeyFactory.INSTANCE;
+    NamedFactory<UserAuth> none = UserAuthNoneFactory.INSTANCE;
 
     private NamedFactory<UserAuth> select() {
         final Jenkins jenkins = Jenkins.getInstance();


### PR DESCRIPTION
Helpful, if not strictly required, for https://github.com/jenkinsci/jenkins/pull/2795. Cf. #8.

Note that `sshd-core` is not compatible across the 1.0 boundary (hence the `src/main/java/` changes), but
* It should not matter for typical plugins since the only extension point from Jenkins is `SshCommandFactory`, which is only referring to `Command`, which does not seem to have changed in interface (including its transitive dependencies) since 0.x.
* `cloudbees-ssh-slaves` uses 0.13.0 and would not compile against 1.x, but it declares an explicit dependency and uses `pluginFirstClassLoader`.
* `ssh-agent` uses 1.0 and `pluginFirstClassLoader`.
* `remote-terminal-access` uses Jenkins’ version and will not work with 1.x, but only in the commands that would be broken by https://github.com/jenkinsci/jenkins/pull/2795 anyway (at least without using deprecated Remoting mode); it _could_ probably be fixed up to work in Remoting mode by using the `pluginFirstClassLoader` trick.
* Some test code in various places may be broken, particularly in `plugin-compat-tester`, but this is not a user issue and is easily solved by declaring an explicit `test`-scoped dependency on 1.x.

@reviewbybees