### PR TITLE
[JENKINS-43668] - Remove Trilead references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.580.3</jenkins.version>
-    <java.level>6</java.level>
-    <jenkins-test-harness.version>1.580.3</jenkins-test-harness.version>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
+    <jenkins-test-harness.version>1.625.3</jenkins-test-harness.version>
   </properties>
 
   <build>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
-      <version>1.1</version>
+      <version>1.4</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org</url>
+      <url>https://repo.jenkins-ci.org/public</url>
     </repository>
   </repositories>
   <pluginRepositories>
       <pluginRepository>
           <id>repo.jenkins-ci.org</id>
-          <url>https://repo.jenkins-ci.org</url>
+          <url>https://repo.jenkins-ci.org/public</url>
       </pluginRepository>
   </pluginRepositories>
 </project>

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -1,16 +1,12 @@
 package org.jenkinsci.main.modules.sshd;
 
-import com.trilead.ssh2.crypto.Base64;
-import com.trilead.ssh2.packets.TypesWriter;
 import hudson.model.User;
 import org.apache.sshd.server.PublickeyAuthenticator;
 import org.apache.sshd.server.session.ServerSession;
+import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 
 import java.security.PublicKey;
-import java.security.interfaces.DSAParams;
-import java.security.interfaces.DSAPublicKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.logging.Logger;
 
 /**
@@ -20,6 +16,9 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
+
+    private final PublicKeySignatureWriter signatureWriter = new PublicKeySignatureWriter();
+
     public boolean authenticate(String username, PublicKey key, ServerSession session) {
         LOGGER.fine("Authentication attempted from "+username+" with "+key);
         User u = User.get(username, false);
@@ -34,35 +33,13 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
             return false;
         }
 
-        // TODO: use sshKey.has() when we can depend on 1.446 or later
-        if (!sshKey.isAuthorizedKey(getPublicKeySignature(key))) {
-            LOGGER.fine("Key signature didn't match for the user: "+username+" : "+getPublicKeySignature(key));
+        String signature = signatureWriter.asString(key);
+        if (!sshKey.isAuthorizedKey(signature)) {
+            LOGGER.fine("Key signature didn't match for the user: "+username+" : " + signature);
             return false;
         }
 
         return true;
-    }
-
-    private static String getPublicKeySignature(PublicKey pk) {
-        TypesWriter tw = new TypesWriter();
-        if (pk instanceof RSAPublicKey) {
-            RSAPublicKey rpk = (RSAPublicKey) pk;
-            tw.writeString("ssh-rsa");
-            tw.writeMPInt(rpk.getPublicExponent());
-            tw.writeMPInt(rpk.getModulus());
-            return new String(Base64.encode(tw.getBytes()));
-        }
-        if (pk instanceof DSAPublicKey) {
-            DSAPublicKey rpk = (DSAPublicKey) pk;
-            tw.writeString("ssh-dss");
-            DSAParams p = rpk.getParams();
-            tw.writeMPInt(p.getP());
-            tw.writeMPInt(p.getQ());
-            tw.writeMPInt(p.getG());
-            tw.writeMPInt(rpk.getY());
-            return new String(Base64.encode(tw.getBytes()));
-        }
-        throw new IllegalArgumentException("Unknown key type: "+pk);
     }
 
     private static final Logger LOGGER = Logger.getLogger(PublicKeyAuthenticatorImpl.class.getName());


### PR DESCRIPTION
[JENKINS-43610] Move to latest version of ssh-cli-auth to remove Trilead references from SSHD module