### PR TITLE
[FIXED JENKINS-39738] - Enable aes192ctr and aes256ctr ciphers if JVM supports them

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -108,7 +108,7 @@ public class SSHD extends GlobalConfiguration {
                 if (c.isSupported()) {
                     activatedCiphers.add(cipher);
                 } else {
-                    LOGGER.log(Level.WARNING, "Discovered unsupported built-in Cipher: {0}. It won't be enabled", c);
+                    LOGGER.log(Level.FINE, "Discovered unsupported built-in Cipher: {0}. It won't be enabled", c);
                 }
             } else {
                 // We cannot determine if the cipher is supported, but the default configuration lists only Built-in ciphers.

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -108,7 +108,7 @@ public class SSHD extends GlobalConfiguration {
                 if (c.isSupported()) {
                     activatedCiphers.add(cipher);
                 } else {
-                    LOGGER.log(Level.FINE, "Discovered unsupported built-in Cipher: {0}. It won't be enabled", c);
+                    LOGGER.log(Level.FINE, "Discovered unsupported built-in Cipher: {0}. It will not be enabled", c);
                 }
             } else {
                 // We cannot determine if the cipher is supported, but the default configuration lists only Built-in ciphers.

--- a/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
@@ -1,5 +1,6 @@
-package org.jenkinsci.main.modules.ssh;
+package org.jenkinsci.main.modules.sshd;
 
+import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.main.modules.sshd.SSHD;
 import org.junit.Rule;
@@ -7,8 +8,12 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import javax.inject.Inject;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.cipher.Cipher;
+import org.junit.Assert;
 
 import static org.junit.Assert.assertThat;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * Tests of {@link SSHD}.
@@ -33,5 +38,13 @@ public class SSHDTest {
             j.configRoundtrip();
             assertThat("SSHD has not been allocated to the specified port", sshd.getPort(), CoreMatchers.equalTo(i));
         }
+    }
+    
+    @Test
+    @Issue("JENKINS-39738")
+    public void checkActivatedCiphers() throws Exception {
+        // Just ensure the method does not blow up && that at least one Cipher is available
+        List<NamedFactory<Cipher>> activatedCiphers = SSHD.getActivatedCiphers();
+        Assert.assertTrue("At least one cipher should be activated", activatedCiphers.size() >= 1);
     }
 }


### PR DESCRIPTION
If the JVM supports unlimited-strength encryption, we can enable more ciphers.
And the new SSHD core version provides good API for it.

CBC ciphers won't be added due to https://www.kb.cert.org/vuls/id/958563 . So it is not exactly what has been requested in [JENKINS-39738](https://issues.jenkins-ci.org/browse/JENKINS-39738) though I think it is a reasonable fix. 

@reviewbybees @jglick + @johnou @chillum since it was raised in https://github.com/jenkinsci/sshd-module/pull/5#discussion_r88207121