### PR TITLE
Update to SSHD 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
This version picks the release with EdDSA 1.2. It unblocks merging of SSHD into the core, which was not possible due to the binary conflict between EdDSA 1.2 in Trilead-SSH2 and EdDSA 1.1 in SSHD. See https://github.com/jenkinsci/jenkins/pull/2853 and https://github.com/jenkinsci/jenkins/pull/2848 for more info

Changelogs:
* 1.5.0 has been burned 
* [SSHD 1.6.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12340583&styleName=&projectId=12310849&Create=Create&atl_token=A5KQ-2QAV-T4JA-FDED%7C1ba4a61d9aff8c9b2113db16bd22472cf1334e04%7Clout)


Full diff: https://github.com/apache/mina-sshd/compare/sshd-1.4.0...sshd-1.6.0

@reviewbybees @paladox @mc1arke 