### PR TITLE
Async startup of the SSHD server

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -64,7 +64,7 @@ public class SSHD extends GlobalConfiguration {
      * Returns the configured port to run SSHD.
      *
      * @return
-     *      -1 to disable this, 0 to run with a random port, otherwise the port number.
+     *      -1 if disabled, 0 if random port is selected, otherwise the port number configured.
      */
     public int getPort() {
         return port;
@@ -73,7 +73,7 @@ public class SSHD extends GlobalConfiguration {
     /**
      * Gets the current TCP/IP port that this daemon is running with.
      *
-     * @return -1 if disabled, but never null.
+     * @return Actual port number or -1 if disabled.
      */
     public synchronized int getActualPort() {
         if (port==-1)   return -1;
@@ -82,6 +82,11 @@ public class SSHD extends GlobalConfiguration {
         return port;
     }
 
+    /**
+     * Set the port number to be used.
+     *
+     * @param port -1 to disable this, 0 to run with a random port, otherwise the port number.
+     */
     public void setPort(int port) {
         if (this.port!=port) {
             this.port = port;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
+
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins.MasterComputer;
@@ -206,7 +207,15 @@ public class SSHD extends GlobalConfiguration {
 
     @Initializer(after= InitMilestone.JOB_LOADED,fatal=false)
     public static void init() throws IOException, InterruptedException {
-        get().start();
+        MasterComputer.threadPoolForRemoting.submit(new Runnable() {
+            @Override public void run() {
+                try {
+                    get().start();
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, "Failed to start SSHD", e);
+                }
+            }
+        });
     }
 
     private static Logger MINA_LOGGER = Logger.getLogger("org.apache.sshd");

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -125,6 +125,7 @@ public class SSHD extends GlobalConfiguration {
     }
     
     public synchronized void start() throws IOException, InterruptedException {
+        int port = this.port; // Capture local copy to prevent race conditions. Setting port to -1 after the check would blow up later.
         if (port<0) return; // don't start it
 
         stop();


### PR DESCRIPTION
- Fix race condition in `SSHD.start()`.
- Do not let Jenkins to wait until `SSHD` is fully up.
  - I have seen launch stuck for minutes while running parallel `jenkins-test-harness` tests as it was waiting for system entropy to launch a service I do not care for on the first place.
- Some javadoc fixes while on it.