### PR TITLE
Update Plugin POM, resolve upper bounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>2.36</version>
     <relativePath />
   </parent>
 
@@ -33,11 +33,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.6.1</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>


### PR DESCRIPTION
Pick new version of parent POM && Stop bundling the obsolete `slf4j-api`. `org.slf4j:slf4j-api:1.7.25` comes from the new SSHD core we bundle.

@reviewbybees