### PR TITLE
[JENKINS-27026] Fire authentication events when using SSH

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -81,7 +81,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
     private static final Logger LOGGER = Logger.getLogger(PublicKeyAuthenticatorImpl.class.getName());
 
     public static class SSHUserDetails extends org.acegisecurity.userdetails.User {
-        /* protected */ SSHUserDetails(@Nonnull String username, @Nonnull Authentication auth) {
+        private SSHUserDetails(@Nonnull String username, @Nonnull Authentication auth) {
             super(
                     username, "",
                     // account validity booleans

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -13,7 +13,6 @@ import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.security.PublicKey;
-import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,7 +47,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
 
     private @CheckForNull User retrieveOnlyKeyValidatedUser(String username, PublicKey key) {
         LOGGER.log(Level.FINE, "Authentication attempted from {0} with {1}", new Object[]{ username, key });
-        User u = User.get(username, false, Collections.emptyMap());
+        User u = User.getById(username, false);
         if (u == null) {
             LOGGER.log(Level.FINE, "No such user exists: {0}", new Object[]{ username });
             return null;
@@ -62,7 +61,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
 
         String signature = signatureWriter.asString(key);
         if (!sshKey.isAuthorizedKey(signature)) {
-            LOGGER.log(Level.FINE,"Key signature didn't match for the user: {0} : {1}", new Object[]{ username, signature });
+            LOGGER.log(Level.FINE,"Key signature did not match for the user: {0} : {1}", new Object[]{ username, signature });
             return null;
         }
 
@@ -73,7 +72,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
         try {
             return user.impersonate();
         } catch (UsernameNotFoundException e) {
-            LOGGER.log(Level.FINE, user.getId() + " is not a real user accordingly to SecurityRealm", e);
+            LOGGER.log(Level.FINE, user.getId() + " is not a real user according to SecurityRealm", e);
             return null;
         }
     }

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -47,22 +47,22 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
     }
 
     private @CheckForNull User retrieveOnlyKeyValidatedUser(String username, PublicKey key) {
-        LOGGER.fine("Authentication attempted from " + username + " with " + key);
+        LOGGER.log(Level.FINE, "Authentication attempted from {0} with {1}", new Object[]{ username, key });
         User u = User.get(username, false, Collections.emptyMap());
         if (u == null) {
-            LOGGER.fine("No such user exists: " + username);
+            LOGGER.log(Level.FINE, "No such user exists: {0}", new Object[]{ username });
             return null;
         }
 
         UserPropertyImpl sshKey = u.getProperty(UserPropertyImpl.class);
         if (sshKey == null) {
-            LOGGER.fine("No SSH key registered for user: " + username);
+            LOGGER.log(Level.FINE, "No SSH key registered for user: {0}", new Object[]{ username });
             return null;
         }
 
         String signature = signatureWriter.asString(key);
         if (!sshKey.isAuthorizedKey(signature)) {
-            LOGGER.fine("Key signature didn't match for the user: " + username + " : " + signature);
+            LOGGER.log(Level.FINE,"Key signature didn't match for the user: {0} : {1}", new Object[]{ username, signature });
             return null;
         }
 
@@ -80,7 +80,15 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
 
     private static final Logger LOGGER = Logger.getLogger(PublicKeyAuthenticatorImpl.class.getName());
 
-    public static class SSHUserDetails extends org.acegisecurity.userdetails.User {
+    /**
+     * UserDetails built from the authentication provided by {@link User#impersonate()}.
+     * It's not completely accurate since the internal UserDetails used in impersonate is not exposed at the moment
+     *
+     * TODO temporary solution since the User#getUserDetailsForImpersonation is not implemented
+     * https://github.com/jenkinsci/jenkins/pull/3074
+     * Will be removed in future version (with higher jenkins version dependency)
+     */
+    private static class SSHUserDetails extends org.acegisecurity.userdetails.User {
         private SSHUserDetails(@Nonnull String username, @Nonnull Authentication auth) {
             super(
                     username, "",

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -1,12 +1,16 @@
 package org.jenkinsci.main.modules.sshd;
 
 import hudson.model.User;
+import jenkins.model.Jenkins;
+import jenkins.security.SecurityListener;
+import org.acegisecurity.userdetails.UserDetails;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.session.ServerSession;
 import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 
 import java.security.PublicKey;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 /**
@@ -20,27 +24,40 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
     private final PublicKeySignatureWriter signatureWriter = new PublicKeySignatureWriter();
 
     public boolean authenticate(String username, PublicKey key, ServerSession session) {
+        boolean authenticated = this.processAuthenticate(username, key);
+
+        if(authenticated){
+            UserDetails userDetails = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(username);
+            SecurityListener.fireAuthenticated(userDetails);
+        }else{
+            SecurityListener.fireFailedToAuthenticate(username);
+        }
+
+        return authenticated;
+    }
+    
+    private boolean processAuthenticate(String username, PublicKey key) {
         LOGGER.fine("Authentication attempted from "+username+" with "+key);
-        User u = User.get(username, false);
+        User u = User.get(username, false, Collections.emptyMap());
         if (u==null) {
             LOGGER.fine("No such user exists: "+username);
             return false;
         }
-
+    
         UserPropertyImpl sshKey = u.getProperty(UserPropertyImpl.class);
         if (sshKey==null) {
             LOGGER.fine("No SSH key registered for user: "+username);
             return false;
         }
-
+    
         String signature = signatureWriter.asString(key);
         if (!sshKey.isAuthorizedKey(signature)) {
             LOGGER.fine("Key signature didn't match for the user: "+username+" : " + signature);
             return false;
         }
-
+    
         return true;
     }
-
+    
     private static final Logger LOGGER = Logger.getLogger(PublicKeyAuthenticatorImpl.class.getName());
 }

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -35,7 +35,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
 
         return authenticated;
     }
-    
+
     private boolean processAuthenticate(String username, PublicKey key) {
         LOGGER.fine("Authentication attempted from "+username+" with "+key);
         User u = User.get(username, false, Collections.emptyMap());
@@ -43,21 +43,21 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
             LOGGER.fine("No such user exists: "+username);
             return false;
         }
-    
+
         UserPropertyImpl sshKey = u.getProperty(UserPropertyImpl.class);
         if (sshKey==null) {
             LOGGER.fine("No SSH key registered for user: "+username);
             return false;
         }
-    
+
         String signature = signatureWriter.asString(key);
         if (!sshKey.isAuthorizedKey(signature)) {
             LOGGER.fine("Key signature didn't match for the user: "+username+" : " + signature);
             return false;
         }
-    
+
         return true;
     }
-    
+
     private static final Logger LOGGER = Logger.getLogger(PublicKeyAuthenticatorImpl.class.getName());
 }


### PR DESCRIPTION
When using SSH to connect with CLI, we do not have event triggered by SecurityListener. With the proposed modifications, our listeners will also receive information when a user tried to authenticate (with success or not)

See [JENKINS-27026](https://issues.jenkins-ci.org/browse/JENKINS-27026).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fire security events when SSH transport is used for CLI authentication

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
