### PR TITLE
[JENKINS-32510] Use a non-blocking random factory so startup doesn't block

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,8 @@
+Apache MINA SSHD
+Copyright 2008-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Please refer to each LICENSE.<component>.txt file for the
+license terms of the components that Apache MINA depends on.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.19</version>
     <relativePath />
   </parent>
 
@@ -47,6 +47,12 @@
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
       <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.58</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -26,9 +26,14 @@ import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.cipher.Cipher;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
+import org.apache.sshd.common.random.JceRandomFactory;
+import org.apache.sshd.common.random.SingletonRandomFactory;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.server.ServerBuilder;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.UserAuth;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
+import org.jenkinsci.main.modules.sshd.random.BouncyCastleNonBlockingRandomFactory;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -132,7 +137,11 @@ public class SSHD extends GlobalConfiguration {
         LOGGER.fine("starting SSHD");
 
         stop();
-        sshd = SshServer.setUpDefaultServer();
+        sshd = ServerBuilder.builder()
+                .randomFactory(new SingletonRandomFactory(SecurityUtils.isBouncyCastleRegistered()
+                        ? BouncyCastleNonBlockingRandomFactory.INSTANCE
+                        : JceRandomFactory.INSTANCE))
+                .build();
 
         sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthNamedFactory()));
         

--- a/src/main/java/org/jenkinsci/main/modules/sshd/random/BouncyCastleNonBlockingRandom.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/random/BouncyCastleNonBlockingRandom.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jenkinsci.main.modules.sshd.random;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import org.apache.sshd.common.random.AbstractRandom;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.bouncycastle.crypto.prng.RandomGenerator;
+import org.bouncycastle.crypto.prng.VMPCRandomGenerator;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * BouncyCastle <code>Random</code>.
+ * This pseudo random number generator uses the a very fast PRNG from BouncyCastle.
+ * The JRE random will be used when creating a new generator to add some random
+ * data to the seed.
+ *
+ * Adapted for Jenkins from <a href="https://github.com/apache/mina-sshd/blob/sshd-1.7.0/sshd-core/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleRandom.java">BouncyCastleRandom</a> 
+ */
+@Restricted(NoExternalUse.class)
+public final class BouncyCastleNonBlockingRandom extends AbstractRandom {
+    public static final String NAME = SecurityUtils.BOUNCY_CASTLE;
+    private final RandomGenerator random;
+
+    public BouncyCastleNonBlockingRandom() {
+        ValidateUtils.checkTrue(SecurityUtils.isBouncyCastleRegistered(), "BouncyCastle not registered");
+        this.random = new VMPCRandomGenerator();
+        // BEGIN JENKINS MODIFICATIONS
+        byte[] seed = new byte[8];
+        try {
+            // Uses /dev/urandom, which should not block.
+            SecureRandom.getInstance("NativePRNGNonBlocking").generateSeed(8);
+        } catch (NoSuchAlgorithmException e) {
+            // Original code from SSHD. This path will always be taken on Windows.
+            seed = new SecureRandom().generateSeed(8);
+        }
+        // END JENKINS MODIFICATIONS
+        this.random.addSeedMaterial(seed);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void fill(byte[] bytes, int start, int len) {
+        this.random.nextBytes(bytes, start, len);
+    }
+
+    /**
+     * Returns a pseudo-random uniformly distributed {@code int}
+     * in the half-open range [0, n).
+     */
+    @Override
+    public int random(int n) {
+        ValidateUtils.checkTrue(n > 0, "Limit must be positive: %d", n);
+        if ((n & -n) == n) {
+            return (int) ((n * (long) next(31)) >> 31);
+        }
+
+        int bits;
+        int val;
+        do {
+            bits = next(31);
+            val = bits % n;
+        } while (bits - val + (n - 1) < 0);
+        return val;
+    }
+
+    private int next(int numBits) {
+        int bytes = (numBits + 7) / 8;
+        byte next[] = new byte[bytes];
+        int ret = 0;
+        random.nextBytes(next);
+        for (int i = 0; i < bytes; i++) {
+            ret = (next[i] & 0xFF) | (ret << 8);
+        }
+        return ret >>> (bytes * 8 - numBits);
+    }
+}

--- a/src/main/java/org/jenkinsci/main/modules/sshd/random/BouncyCastleNonBlockingRandomFactory.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/random/BouncyCastleNonBlockingRandomFactory.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.main.modules.sshd.random;
+
+import org.apache.sshd.common.random.AbstractRandomFactory;
+import org.apache.sshd.common.random.Random;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * RandomFactory that should never block.
+ *
+ * Adapted for Jenkins from <a href="https://github.com/apache/mina-sshd/blob/sshd-1.7.0/sshd-core/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleRandomFactory.java">BouncyCastleRandomFactory</a>
+ */
+@Restricted(NoExternalUse.class)
+public class BouncyCastleNonBlockingRandomFactory extends AbstractRandomFactory {
+    public static final String NAME = "non-blocking-bouncycastle";
+    public static final BouncyCastleNonBlockingRandomFactory INSTANCE = new BouncyCastleNonBlockingRandomFactory();
+
+    protected BouncyCastleNonBlockingRandomFactory() {
+        super(NAME);
+    }
+
+    @Override
+    public boolean isSupported() {
+        return SecurityUtils.isBouncyCastleRegistered();
+    }
+
+    @Override
+    public Random create() {
+        return new BouncyCastleNonBlockingRandom();
+    }
+}


### PR DESCRIPTION
See [JENKINS-32510](https://issues.jenkins-ci.org/browse/JENKINS-32510).

This code should behave identically to the current code, except that the seed generation for BouncyCastleNonBlockingRandom will use Sun's NativePRNGNonBlocking provider instead of the system default. The most common default uses `/dev/random`, which blocks, as the underlying source for calls to SecureRandom#generateSeed, but the NativePRNGNonBlocking provider will always use `/dev/urandom`.