### PR TITLE
[JENKINS-55978] - Apache Mina idle timeout configuration only delays the session timeout by 15 seconds

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
@@ -5,9 +5,14 @@ import org.apache.sshd.server.SshServer;
 
 import java.util.logging.Logger;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 /**
+ * Utility class which properly manages Apache MINA idle timeout, see JENKINS-55978 
  * @author Réda Housni Alaoui
  */
+@Restricted(NoExternalUse.class)
 public class IdleTimeout {
 
 	private static final Logger LOGGER = Logger.getLogger(IdleTimeout.class.getName());

--- a/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.main.modules.sshd;
+
+import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.server.SshServer;
+
+import java.util.logging.Logger;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class IdleTimeout {
+
+	private static final Logger LOGGER = Logger.getLogger(IdleTimeout.class.getName());
+
+	private final Long timeoutInMilliseconds;
+
+	IdleTimeout(Long timeoutInMilliseconds) {
+		this.timeoutInMilliseconds = timeoutInMilliseconds;
+	}
+
+	public static IdleTimeout fromSystemProperty(String propertyName) {
+		String propertyValue = System.getProperty(propertyName);
+		if (propertyValue == null) {
+			return new IdleTimeout(null);
+		}
+
+		try {
+			return new IdleTimeout(Long.parseLong(propertyValue));
+		} catch (NumberFormatException nfe) {
+			LOGGER.warning("SSHD Idle Timeout configuration skipped. " + propertyName + " value (" +
+					propertyValue + ") isn't a long.");
+		}
+		return new IdleTimeout(null);
+	}
+
+	public void apply(SshServer sshd) {
+		if (timeoutInMilliseconds == null) {
+			return;
+		}
+
+		sshd.getProperties().put(ServerFactoryManager.IDLE_TIMEOUT, timeoutInMilliseconds);
+		// Read timeout must also be changed
+		long readTimeout = 0;
+		if (timeoutInMilliseconds != 0) {
+			readTimeout = ServerFactoryManager.DEFAULT_NIO2_READ_TIMEOUT - ServerFactoryManager.DEFAULT_IDLE_TIMEOUT + timeoutInMilliseconds;
+		}
+		sshd.getProperties().put(ServerFactoryManager.NIO2_READ_TIMEOUT, readTimeout);
+	}
+
+}

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -26,7 +26,6 @@ import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.cipher.Cipher;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
-import org.apache.sshd.server.ServerFactoryManager;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.UserAuth;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
@@ -154,24 +153,7 @@ public class SSHD extends GlobalConfiguration {
 
         // Allow to configure idle timeout with a system property
         String idleTimeoutPropertyName = SSHD.class.getName() + "." + IDLE_TIMEOUT_KEY;
-        String idleTimeout = System.getProperty(idleTimeoutPropertyName);
-        if (idleTimeout != null) {
-            try {
-                // In sshd-core 0.8.0 it must be an int
-                // https://github.com/apache/mina-sshd/blob/sshd-0.8.0/sshd-core/src/main/java/org/apache/sshd/server/session/ServerSession.java#L68
-                int idleTimeoutAsInt = Integer.parseInt(idleTimeout);
-                sshd.getProperties().put(ServerFactoryManager.IDLE_TIMEOUT, idleTimeoutAsInt);
-                // Read timeout must also be changed
-                long readTimeout = 0;
-                if (idleTimeoutAsInt != 0) {
-                    readTimeout = ServerFactoryManager.DEFAULT_NIO2_READ_TIMEOUT - ServerFactoryManager.DEFAULT_IDLE_TIMEOUT + idleTimeoutAsInt;
-                }
-                sshd.getProperties().put(ServerFactoryManager.NIO2_READ_TIMEOUT, readTimeout);
-            } catch (NumberFormatException nfe) {
-                LOGGER.warning("SSHD Idle Timeout configuration skipped. " + idleTimeoutPropertyName + " value (" +
-                        idleTimeout + ") isn't an integer.");
-            }
-        }
+        IdleTimeout.fromSystemProperty(idleTimeoutPropertyName).apply(sshd);
 
         sshd.start();
         LOGGER.info("Started SSHD at port " + sshd.getPort());

--- a/src/test/java/org/jenkinsci/main/modules/sshd/IdleTimeoutTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/sshd/IdleTimeoutTest.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.main.modules.sshd;
+
+
+import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.server.SshServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class IdleTimeoutTest {
+
+	private SshServer sshd;
+
+	@Before
+	public void before() {
+		sshd = new SshServer();
+	}
+
+	@Test
+	public void applyEmptyTimeout() {
+		IdleTimeout idleTimeout = new IdleTimeout(null);
+
+		idleTimeout.apply(sshd);
+
+		Map<String, Object> properties = sshd.getProperties();
+		Assert.assertFalse(properties.containsKey(ServerFactoryManager.IDLE_TIMEOUT));
+		Assert.assertFalse(properties.containsKey(ServerFactoryManager.NIO2_READ_TIMEOUT));
+	}
+
+	@Test
+	public void apply24HoursTimeout() {
+		IdleTimeout idleTimeout = new IdleTimeout(TimeUnit.HOURS.toMillis(24));
+
+		idleTimeout.apply(sshd);
+
+		Map<String, Object> properties = sshd.getProperties();
+		Assert.assertEquals(86400000L, properties.get(ServerFactoryManager.IDLE_TIMEOUT));
+		Object readTimeout = properties.get(ServerFactoryManager.NIO2_READ_TIMEOUT);
+		Assert.assertTrue(readTimeout instanceof Long);
+		Assert.assertTrue((Long) readTimeout > 86400000L);
+	}
+
+	@Test
+	public void applyFromAbsentSystemProperty() {
+		IdleTimeout idleTimeout = IdleTimeout.fromSystemProperty(IdleTimeoutTest.class.getName());
+
+		idleTimeout.apply(sshd);
+
+		Map<String, Object> properties = sshd.getProperties();
+		Assert.assertFalse(properties.containsKey(ServerFactoryManager.IDLE_TIMEOUT));
+		Assert.assertFalse(properties.containsKey(ServerFactoryManager.NIO2_READ_TIMEOUT));
+	}
+
+}


### PR DESCRIPTION
https://github.com/jenkinsci/sshd-module/pull/6 is not enough, it only delays the timeout by 15 seconds.
Apache Mina's read timeout defaults to default idle timeout (10 minutes) + 15 seconds.

This PR makes sure read timeout follows idle timeout value.