### PR TITLE
Update to latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.36</version>
     <relativePath />
   </parent>
 
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.1</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Updated also instance-identity-module to solve a RequireUpperBoundDeps
issue when building with JDK 11 and Jenkins 2.161:

```
$ mvn -V -Djenkins.version=2.143 clean verify
...
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.jenkins-ci.modules:instance-identity:2.1 paths to dependency are:
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.modules:instance-identity:2.1
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.modules:ssh-cli-auth:1.4
    +-org.jenkins-ci.modules:instance-identity:1.2
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.143
    +-org.jenkins-ci.modules:instance-identity:2.2
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.143
    +-org.jenkins-ci.modules:slave-installer:1.6
      +-org.jenkins-ci.modules:instance-identity:1.1
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.143
    +-org.jenkins-ci.modules:windows-slave-installer:1.9.2
      +-org.jenkins-ci.modules:instance-identity:1.4
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.143
    +-org.jenkins-ci.modules:launchd-slave-installer:1.2
      +-org.jenkins-ci.modules:instance-identity:1.1
and
+-org.jenkins-ci.modules:sshd:2.6-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.143
    +-org.jenkins-ci.modules:sshd:2.4
      +-org.jenkins-ci.modules:instance-identity:2.1
]
```

@jenkinsci/java11-support 