### PR TITLE
Use sshd 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>1.7.0</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -4,7 +4,7 @@ import hudson.model.User;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import org.acegisecurity.context.SecurityContextHolder;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SessionAware;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/CLICommandAdapter.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/CLICommandAdapter.java
@@ -3,8 +3,7 @@ package org.jenkinsci.main.modules.sshd;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.model.User;
-import jenkins.model.Jenkins;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 
 import java.io.PrintStream;
 import java.nio.charset.Charset;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/CommandFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/CommandFactoryImpl.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.main.modules.sshd;
 
-import org.apache.sshd.server.Command;
-import org.apache.sshd.server.CommandFactory;
+import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.command.CommandFactory;
 import org.jenkinsci.main.modules.sshd.SshCommandFactory.CommandLine;
 
 /**

--- a/src/main/java/org/jenkinsci/main/modules/sshd/InvalidCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/InvalidCommand.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.main.modules.sshd;
 
-import org.apache.sshd.server.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.command.Command;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -26,6 +26,7 @@ import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.cipher.Cipher;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.UserAuth;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
@@ -141,7 +142,7 @@ public class SSHD extends GlobalConfiguration {
 
         sshd.setKeyPairProvider(new AbstractKeyPairProvider() {
             @Override
-            public Iterable<KeyPair> loadKeys() {
+            public Iterable<KeyPair> loadKeys(SessionContext sessionContext) {
                 return Collections.singletonList(new KeyPair(identity.getPublic(),identity.getPrivate()));
             }
         });

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SshCommandFactory.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SshCommandFactory.java
@@ -3,8 +3,7 @@ package org.jenkinsci.main.modules.sshd;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.util.QuotedStringTokenizer;
-import jenkins.model.Jenkins;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 
 import java.util.AbstractList;
 import java.util.Arrays;


### PR DESCRIPTION
Implements part of [JENKINS-60902](https://issues.jenkins-ci.org/browse/JENKINS-60902)

Some other projects that use sshd-core, which are also used in Jenkins plugins e.g. the JGit utilities, have moved on to SSHD 2.x. As a result we sometimes get class not found errors due to the incompatibilities. Bump the SSHD dependency to fix this.