### PR TITLE
Filter out SHA-1 key exchanges and MD5/truncated SHA-1 MACs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,10 @@ These are generally considered unsupported, i.e. may be removed at any time.
   By default, this disables SHA-1 based algorithms as they're no longer considered safe.
   Use an empty string to disable no algorithms.
   The names of supported, enabled, and disabled algorithms can be viewed using the https://www.jenkins.io/doc/book/system-administration/viewing-logs/[logger] `org.jenkinsci.main.modules.sshd.SSHD` during initialization on the level `FINE`.
+* `org.jenkinsci.main.modules.sshd.SSHD.excludedMacs` is a comma-separated string of HMAC algorithms to disable.
+  By default, this disables MD5 and truncated SHA-1 based algorithms as they're no longer considered safe.
+  Use an empty string to disable no algorithms.
+  The names of supported, enabled, and disabled algorithms can be viewed using the https://www.jenkins.io/doc/book/system-administration/viewing-logs/[logger] `org.jenkinsci.main.modules.sshd.SSHD` during initialization on the level `FINE`.
 
 == Changelog
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,26 @@
+= SSHD Module
+
+== About
+
+This component provides a built-in SSH server for Jenkins.
+It's an alternative interface for the https://www.jenkins.io/doc/book/managing/cli/[Jenkins CLI], and commands can be invoked this way using any SSH client.
+
+NOTE: This is unrelated to https://plugins.jenkins.io/ssh-slaves/[SSH Build Agents]. In that case, the agents are the servers, and the Jenkins controller is the client.
+
+== Configuration
+
+Enable the built-in SSH server in _Manage Jenkins » Configure Global Security_.
+
+=== Advanced Configuration
+
+https://www.jenkins.io/doc/book/managing/system-properties/[System properties] can be used to configure hidden options.
+These are generally considered unsupported, i.e. may be removed at any time.
+
+* `org.jenkinsci.main.modules.sshd.SSHD.excludedKeyExchanges` is a comma-separated string of key exchange algorithms to disable.
+  By default, this disables SHA-1 based algorithms as they're no longer considered safe.
+  Use an empty string to disable no algorithms.
+  The names of supported, enabled, and disabled algorithms can be viewed using the https://www.jenkins.io/doc/book/system-administration/viewing-logs/[logger] `org.jenkinsci.main.modules.sshd.SSHD` during initialization on the level `FINE`.
+
+== Changelog
+
+See link:CHANGELOG.md[CHANGELOG.md].

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
+      <version>1.8</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.7</version>
     <relativePath />
   </parent>
 
@@ -31,7 +31,7 @@
   <properties>
     <revision>2.7</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.89.3</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
-      <version>1.5</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForSigned;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
@@ -20,11 +21,14 @@ import javax.inject.Inject;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.util.ServerTcpPort;
+import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.cipher.Cipher;
+import org.apache.sshd.common.kex.KeyExchange;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.UserAuth;
@@ -44,6 +48,12 @@ public class SSHD extends GlobalConfiguration {
     private static final List<NamedFactory<Cipher>> ENABLED_CIPHERS = Arrays.<NamedFactory<Cipher>>asList(
         BuiltinCiphers.aes128ctr, BuiltinCiphers.aes192ctr, BuiltinCiphers.aes256ctr
     );
+
+    /**
+     * Comma-separated string of key exchange names to disable. Defaults to a list of DH SHA1 key exchanges, gets its value from {@link SystemProperties}.
+     */
+    private static final String EXCLUDED_KEY_EXCHANGES = SystemProperties.getString(SSHD.class.getName() + ".excludedKeyExchanges",
+            "diffie-hellman-group-exchange-sha1, diffie-hellman-group14-sha1, diffie-hellman-group1-sha1");
     
     @Override
     public GlobalConfigurationCategory getCategory() {
@@ -125,7 +135,7 @@ public class SSHD extends GlobalConfiguration {
          }
         return activatedCiphers;
     }
-    
+
     public synchronized void start() throws IOException, InterruptedException {
         int port = this.port; // Capture local copy to prevent race conditions. Setting port to -1 after the check would blow up later.
         if (port<0) return; // don't start it
@@ -137,6 +147,7 @@ public class SSHD extends GlobalConfiguration {
         sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthNamedFactory()));
         
         sshd.setCipherFactories(getActivatedCiphers());
+        sshd.setKeyExchangeFactories(filterKeyExchanges(sshd.getKeyExchangeFactories()));
         sshd.setPort(port);
 
         sshd.setKeyPairProvider(new AbstractKeyPairProvider() {
@@ -158,7 +169,32 @@ public class SSHD extends GlobalConfiguration {
         sshd.start();
         LOGGER.info("Started SSHD at port " + sshd.getPort());
     }
-    
+
+    /**
+     * Filter key exchanges based on configuration from {@link #EXCLUDED_KEY_EXCHANGES}.
+     * @param keyExchangeFactories the full list of key exchange factories
+     * @return a filtered list of key exchange factories
+     */
+    private List<NamedFactory<KeyExchange>> filterKeyExchanges(List<NamedFactory<KeyExchange>> keyExchangeFactories) {
+        if (StringUtils.isBlank(EXCLUDED_KEY_EXCHANGES)) {
+            return keyExchangeFactories;
+        }
+
+        List<String> excludedNames = Arrays.stream(EXCLUDED_KEY_EXCHANGES.split(",")).filter(StringUtils::isNotBlank).map(String::trim).collect(Collectors.toList());
+
+        List<NamedFactory<KeyExchange>> filtered = new ArrayList<>();
+        for (NamedFactory<KeyExchange> keyExchangeNamedFactory : keyExchangeFactories) {
+            final String name = keyExchangeNamedFactory.getName();
+            if (excludedNames.contains(name)) {
+                LOGGER.log(Level.CONFIG, "Excluding " + name);
+            } else {
+                LOGGER.log(Level.FINE, "Not excluding " + name);
+                filtered.add(keyExchangeNamedFactory);
+            }
+        }
+        return filtered;
+    }
+
     public synchronized void restart() {
         try {
             if (sshd!=null) {


### PR DESCRIPTION
By default, exclude SHA1 based key exchanges. Allow customizing which to exclude, and add logging to understand exactly what happens during filtering.

Exclusion of SHA1 based key exchanges has been implemented in newer versions of Mina according to https://github.com/apache/mina-sshd#implementedavailable-support but upgrading Mina seems like a bigger project (https://github.com/jenkinsci/sshd-module/pull/33). So choose this approach instead.

If this looks like a reasonable approach, we probably want to disable `hmac-md5`, `hmac-md5-96`, and `hmac-sha1-96` in a similar manner. They are also no longer available by default in Mina 2 (https://issues.apache.org/jira/browse/SSHD-1004).