### PR TITLE
[JENKINS-55813] Ensure account status exceptions prevent successful SSH authentication

### DIFF
--- a/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.main.modules.sshd;
 
+import hudson.Functions;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.GroupDetails;
 import org.acegisecurity.AccountExpiredException;
@@ -20,6 +21,7 @@ import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.cipher.Cipher;
 import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -38,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Tests of {@link SSHD}.
@@ -49,6 +52,11 @@ public class SSHDTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        assumeFalse(Functions.isWindows());
+    }
 
     /**
      * Makes sure 3 mode of the value round-trips correctly

--- a/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/sshd/SSHDTest.java
@@ -1,19 +1,38 @@
 package org.jenkinsci.main.modules.sshd;
 
-import java.util.List;
-import org.hamcrest.CoreMatchers;
-import org.jenkinsci.main.modules.sshd.SSHD;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-
-import javax.inject.Inject;
+import hudson.security.AbstractPasswordBasedSecurityRealm;
+import hudson.security.GroupDetails;
+import org.acegisecurity.AuthenticationException;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.userdetails.User;
+import org.acegisecurity.userdetails.UserDetails;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.future.ConnectFuture;
+import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
+import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.cipher.Cipher;
-import org.junit.Assert;
-
-import static org.junit.Assert.assertThat;
+import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
+import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.springframework.dao.DataAccessException;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests of {@link SSHD}.
@@ -36,15 +55,108 @@ public class SSHDTest {
         for (int i : new int[]{-1,0,100}) {
             sshd.setPort(i);
             j.configRoundtrip();
-            assertThat("SSHD has not been allocated to the specified port", sshd.getPort(), CoreMatchers.equalTo(i));
+            assertEquals("SSHD has not been allocated to the specified port", sshd.getPort(), i);
         }
     }
-    
+
     @Test
     @Issue("JENKINS-39738")
     public void checkActivatedCiphers() throws Exception {
         // Just ensure the method does not blow up && that at least one Cipher is available
         List<NamedFactory<Cipher>> activatedCiphers = SSHD.getActivatedCiphers();
-        Assert.assertTrue("At least one cipher should be activated", activatedCiphers.size() >= 1);
+        assertTrue("At least one cipher should be activated", activatedCiphers.size() >= 1);
+    }
+
+    @Test
+    @Issue("JENKINS-55813")
+    public void enabledUserShouldBeAuthorized() throws Exception {
+        j.jenkins.setSecurityRealm(new InvalidUserTypesRealm());
+        hudson.model.User enabled = hudson.model.User.getOrCreateByIdOrFullName("enabled");
+        KeyPair keyPair = generateKeys(enabled);
+        SSHD server = SSHD.get();
+        server.setPort(0);
+        server.start();
+        try (SshClient client = SshClient.setUpDefaultClient()) {
+            client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE);
+            client.start();
+            ConnectFuture future = client.connect("enabled", new InetSocketAddress(server.getActualPort()));
+            try (ClientSession session = future.verify(10, TimeUnit.SECONDS).getSession()) {
+                session.addPublicKeyIdentity(keyPair);
+                assertTrue(session.auth().await(10, TimeUnit.SECONDS));
+            }
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-55813")
+    public void disabledUserShouldBeUnauthorized() throws Exception {
+        assertUserCannotLoginToSSH("disabled");
+    }
+
+    @Test
+    @Issue("JENKINS-55813")
+    public void lockedUserShouldBeUnauthorized() throws Exception {
+        assertUserCannotLoginToSSH("locked");
+    }
+
+    @Test
+    @Issue("JENKINS-55813")
+    public void expiredUserShouldBeUnauthorized() throws Exception {
+        assertUserCannotLoginToSSH("expired");
+    }
+
+    @Test
+    @Issue("JENKINS-55813")
+    public void passwordExpiredUserShouldBeUnauthorized() throws Exception {
+        assertUserCannotLoginToSSH("password_expired");
+    }
+
+    private void assertUserCannotLoginToSSH(String username) throws Exception {
+        j.jenkins.setSecurityRealm(new InvalidUserTypesRealm());
+        hudson.model.User user = hudson.model.User.getOrCreateByIdOrFullName(username);
+        KeyPair keyPair = generateKeys(user);
+
+        SSHD server = SSHD.get();
+        server.setPort(0);
+        server.start();
+        try (SshClient client = SshClient.setUpDefaultClient()) {
+            client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE);
+            client.start();
+            ConnectFuture future = client.connect(username, new InetSocketAddress(server.getActualPort()));
+            try (ClientSession session = future.verify(10, TimeUnit.SECONDS).getSession()) {
+                session.addPublicKeyIdentity(keyPair);
+                assertThrows(IOException.class, () -> session.auth().verify(10, TimeUnit.SECONDS));
+            }
+        }
+    }
+
+    private static KeyPair generateKeys(hudson.model.User user) throws NoSuchAlgorithmException, IOException {
+        // I'd prefer to generate Ed25519 keys here, but the API is too awkward currently
+        // ECDSA keys would be even more awkward as we'd need a copy of the curve parameters
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        String encodedPublicKey = "ssh-rsa " + new PublicKeySignatureWriter().asString(keyPair.getPublic());
+        user.addProperty(new UserPropertyImpl(encodedPublicKey));
+        return keyPair;
+    }
+
+    @Issue("JENKINS-55813")
+    private static class InvalidUserTypesRealm extends AbstractPasswordBasedSecurityRealm {
+        @Override
+        protected UserDetails authenticate(String user, String pass) throws AuthenticationException {
+            return loadUserByUsername(user);
+        }
+
+        @Override
+        public UserDetails loadUserByUsername(String user) throws UsernameNotFoundException, DataAccessException {
+            return new User(user, "", !user.equals("disabled"), !user.equals("expired"),
+                    !user.equals("password_expired"), !user.equals("locked"), new GrantedAuthority[0]);
+        }
+
+        @Override
+        public GroupDetails loadGroupByGroupname(String group) throws UsernameNotFoundException, DataAccessException {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
This validates that a user logging in through SSH is not bypassing their SecurityRealm user validity attributes. This also updates user impersonation checks to use the core API.

It's an open question on how we'd like to expose a configuration option to admins to enable or disable this attribute check. I think it might make most sense to put the feature flags or config options in the SecurityRealm plugins themselves which can avoid setting dynamic values to those attributes.

https://issues.jenkins.io/browse/JENKINS-55813

This PR was originally part of https://github.com/jenkinsci/jenkins/pull/4925 which has been put aside in favor of directly patching the affected plugins. As such, I've added all the people who left comments on that PR as reviewers if any of you would like to take a look.